### PR TITLE
fix player option types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -88,8 +88,8 @@ interface options {
   playMode?: PLAY_MODE
   startFrame?: number
   endFrame?: number
-  cacheFrames: boolean
-  intersectionObserverRender: boolean
+  cacheFrames?: boolean
+  intersectionObserverRender?: boolean
 }
 
 export class Player {


### PR DESCRIPTION
fix player option types:
 `cacheFrames` and `intersectionObserverRender` are optional
