### PR TITLE
feat: 加入 `loopStartFrame` 参数，设置循环节从中间开始

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ new Player({
   // 结束播放的帧数，默认值 0
   endFrame?: number
 
+  // 循环播放开始的帧数，可设置每次循环从中间开始。默认值 0，每次播放到 endFrame 后，跳转到此帧开始循环，若此值小于 startFrame 则不生效
+  // 类似于 https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/loopStart
+  loopStartFrame?: number
+
   // 是否开启缓存已播放过的帧数据，默认值 false
   // 开启后对已绘制的帧进行缓存，提升重复播放动画性能
   isCacheFrames?: boolean

--- a/src/player/animator.ts
+++ b/src/player/animator.ts
@@ -9,6 +9,7 @@ export class Animator {
   public startValue: number = 0
   public endValue: number = 0
   public duration: number = 0
+  public loopStart: number = 0
   public loop: number = 1
   public fillRule: number = 0
   public onStart: () => void = () => {}
@@ -60,11 +61,13 @@ export class Animator {
   }
 
   private doDeltaTime (deltaTime: number): void {
-    if (deltaTime >= this.duration * this.loop) {
+    if (deltaTime >= this.loopStart + (this.duration - this.loopStart) * this.loop) {
       this.currentFrication = this.fillRule === 1 ? 0.0 : 1.0
       this.isRunning = false
     } else {
-      this.currentFrication = deltaTime % this.duration / this.duration
+      this.currentFrication = deltaTime <= this.duration
+        ? deltaTime / this.duration
+        : ((deltaTime - this.loopStart) % (this.duration - this.loopStart) + this.loopStart) / this.duration
     }
     this.onUpdate(this.animatedValue)
     if (!this.isRunning) {

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -41,6 +41,7 @@ export class Player {
     playMode: PLAYER_PLAY_MODE.FORWARDS,
     startFrame: 0,
     endFrame: 0,
+    loopStartFrame: 0,
     isCacheFrames: false,
     isUseIntersectionObserver: false,
     isOpenNoExecutionDelay: false
@@ -86,6 +87,7 @@ export class Player {
     this.config.playMode = options.playMode ?? PLAYER_PLAY_MODE.FORWARDS
     this.config.startFrame = options.startFrame ?? 0
     this.config.endFrame = options.endFrame ?? 0
+    this.config.loopStartFrame = options.loopStartFrame ?? 0
     this.config.isCacheFrames = options.isCacheFrames ?? false
     this.config.isUseIntersectionObserver = options.isUseIntersectionObserver ?? false
     this.config.isOpenNoExecutionDelay = options.isOpenNoExecutionDelay ?? false
@@ -242,7 +244,7 @@ export class Player {
     if (this.videoEntity === undefined) throw new Error('videoEntity undefined')
 
     const { config, totalFrames, videoEntity } = this
-    const { playMode, startFrame, endFrame, fillMode, loop } = config
+    const { playMode, startFrame, endFrame, loopStartFrame, fillMode, loop } = config
 
     // 如果开始动画的当前帧是最后一帧，重置为第 0 帧
     if (this.currentFrame === totalFrames) {
@@ -267,6 +269,7 @@ export class Player {
     }
 
     this.animator.duration = frames * (1.0 / videoEntity.fps) * 1000
+    this.animator.loopStart = loopStartFrame > startFrame ? (loopStartFrame - startFrame) * (1.0 / videoEntity.fps) * 1000 : 0
     this.animator.loop = loop === true || loop <= 0 ? Infinity : (loop === false ? 1 : loop)
     this.animator.fillRule = fillMode === 'backwards' ? 1 : 0
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,6 +283,10 @@ export interface PlayerConfig {
    */
   endFrame: number
   /**
+   * 循环播放的开始帧，默认值 0
+   */
+  loopStartFrame: number
+  /**
    * 是否开启缓存已播放过的帧数据，默认值 false
    */
   isCacheFrames: boolean


### PR DESCRIPTION
加入 `loopStartFrame` 参数，设置循环节从中间开始。默认值 0，每次播放到 endFrame 后，跳转到此帧开始循环，若此值小于 startFrame 则不生效。

用于实现类似“先弹出礼物，然后循环飘浮在空中”的动画需求。假设“弹出礼物”在第0-20帧，“飘浮在空中”在第20-30帧，此时可设置 `loopStartFrame: 20`。

类似于 https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/loopStart