### PR TITLE
fix(parser): 跳过 audio 开头的图片资源

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,9 @@ const svga = await parser.load(xx)
 
 我们感谢社区提供错误修正和改进。
 
+### 环境要求
+Node.js v16.x
+
 ```sh
 # 安装依赖
 yarn install

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -49,6 +49,7 @@ async function onmessage (event: { data: ParserPostMessageArgs }): Promise<void>
     const movie = message.decode(inflateData) as unknown as Movie
     const images: RawImages = {}
     for (const key in movie.images) {
+      if (key.startsWith('audio')) continue
       const image = movie.images[key]
       if (!options.isDisableImageBitmapShim && self.createImageBitmap !== undefined) {
         images[key] = await self.createImageBitmap(new Blob([image]))
@@ -59,7 +60,7 @@ async function onmessage (event: { data: ParserPostMessageArgs }): Promise<void>
     }
     worker.postMessage(new VideoEntity(movie, images))
   } catch (error) {
-    let errorMessage: string = (error as unknown as any).toString()
+    let errorMessage: string = (error as any).toString()
     if (error instanceof Error) errorMessage = error.message
     worker.postMessage(
       new Error(`[SVGA Parser Error] ${errorMessage}`)


### PR DESCRIPTION
docs(README): 添加环境要求说明

fix(parser): 跳过 audio 开头的图片资源
- 在解析 movie.images 时，忽略以 'audio' 开头的键