### PR TITLE
fix: 导出常用枚举和类型

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,9 @@ export { Player } from './player'
 
 // extension
 export { DB } from './db'
+
+// 常用枚举
+export { PLAYER_FILL_MODE, PLAYER_PLAY_MODE } from './types'
+
+// 常用类型
+export type { ParserConfigOptions, PlayerConfigOptions, PlayerConfig, DynamicElement, DynamicElements, ReplaceElement, ReplaceElements, Video, VideoSprite, VideoFrame, Rect, Transform } from './types'


### PR DESCRIPTION
## 导出常用枚举
`PLAYER_FILL_MODE` 和 `PLAYER_PLAY_MODE` 是传递option时的值，如果直接传字符串，类型会校验不过，需要`as any`

## 导出常用类型
目前的打包方式types.ts内的类型只能强行使用 `import { PlayerConfigOptions } from 'svga/dist/types'`，不符合node的现代包解析规范，在一些打包工具中也会有warning，例如vite会报 _Error: The following dependencies are imported but could not be resolved:_